### PR TITLE
Very minimal & naive lock implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'json', '~> 1.8.3'
 gem 'rest-client', '~> 1.8.0'
 gem 'activesupport', '~> 4.2.3'
+gem 'pmckee11-redis-lock', require: 'redis-lock'
 gem 'coveralls', :require => false, :group => :test
 gem 'simplecov', '~> 0.10.0', :require => false, :group => :test
 gem 'simplecov-console', '~> 0.3.1', :require => false, :group => :test

--- a/invoiced.gemspec
+++ b/invoiced.gemspec
@@ -17,11 +17,13 @@ Gem::Specification.new do |s|
   s.add_dependency('rest-client', '~> 1.8.0')
   s.add_dependency('json', '~> 1.8.3')
   s.add_dependency('activesupport', '~> 4.2.3')
+  s.add_dependency('redis', '~>3.2')
 
   s.add_development_dependency('mocha', '~> 0.13.2')
   s.add_development_dependency('shoulda', '~> 3.4.0')
   s.add_development_dependency('test-unit')
   s.add_development_dependency('rake')
+  s.add_development_dependency('pry')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
When we initialise the Invoiced client with a Redis connection, all requests will be wrapped in a Redis lock, to ensure that we never have more than 20 connections.