### PR TITLE
Log out the instance variable; there is no attr_reader

### DIFF
--- a/lib/invoiced/operations/update.rb
+++ b/lib/invoiced/operations/update.rb
@@ -18,7 +18,7 @@ module Invoiced
                 logger.info("In invoiced gem")
                 logger.info("the params passed in = #{params.inspect}")
                 logger.info("the opts passed in = #{opts.inspect}")
-                logger.info("@unsaved = #{unsaved.inspect}")
+                logger.info("@unsaved = #{@unsaved.inspect}")
 
                 # perform the update if there are any changes
                 if update.length > 0


### PR DESCRIPTION
This pull request fixes the following error

https://rollbar.com/FlickElectric/billing/items/1452/

```
NameError: undefined local variable or method `unsaved' for #<Invoiced::Invoice:0x000055ae0cd7bd78>
Did you mean? @unsaved
1
File "/srv/vendor/bundle/ruby/2.4.0/gems/invoiced-0.13.2/lib/invoiced/object.rb" line 164 in method_missing
2
File "/srv/vendor/bundle/ruby/2.4.0/gems/invoiced-0.13.2/lib/invoiced/operations/update.rb" line 21 in save

```